### PR TITLE
Fix height issue for address bar in mobile browser

### DIFF
--- a/src/Flexo/stylesheets/_reset.scss
+++ b/src/Flexo/stylesheets/_reset.scss
@@ -26,9 +26,9 @@ body {
 
 html,
 body {
+	height: 100%;
 	overflow: hidden;
 	position: relative;
-	height: 100%;
 }
 
 #root,

--- a/src/Flexo/stylesheets/_reset.scss
+++ b/src/Flexo/stylesheets/_reset.scss
@@ -28,6 +28,12 @@ html,
 body {
 	overflow: hidden;
 	position: relative;
+	height: 100%;
+}
+
+#root,
+.App {
+	height: 100%;
 }
 
 html,

--- a/src/Flexo/stylesheets/components/_flex-container.scss
+++ b/src/Flexo/stylesheets/components/_flex-container.scss
@@ -1,6 +1,6 @@
 .flex-container {
 	background-color: $secondary-light;
-	height: calc(100vh - 200px);
+	height: calc(100% - 200px);
 	overflow: auto;
 	position: relative;
 	transition: padding 300ms $timing-func-1,
@@ -16,7 +16,7 @@
 	}
 
 	@include is-mobile {
-		height: calc(100vh - 140px);
+		height: calc(100% - 140px);
 
 		&--with-padding {
 			padding: 0;


### PR DESCRIPTION
- Make all the parent 100% of the height
- Calculate flex-container height using 100%